### PR TITLE
Add Saf CRUD controller service repository

### DIFF
--- a/src/main/java/com/proyectosaf/presupuesto/controller/SafController.java
+++ b/src/main/java/com/proyectosaf/presupuesto/controller/SafController.java
@@ -1,0 +1,45 @@
+package com.proyectosaf.presupuesto.controller;
+
+import com.proyectosaf.presupuesto.persistence.entity.SafEntity;
+import com.proyectosaf.presupuesto.service.SafService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/safs")
+@RequiredArgsConstructor
+public class SafController {
+
+    private final SafService service;
+
+    @GetMapping
+    public List<SafEntity> list() {
+        return service.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public SafEntity get(@PathVariable Integer id) {
+        return service.findById(id);
+    }
+
+    @PostMapping
+    public ResponseEntity<SafEntity> create(@RequestBody SafEntity saf) {
+        SafEntity created = service.create(saf);
+        return new ResponseEntity<>(created, HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    public SafEntity update(@PathVariable Integer id, @RequestBody SafEntity saf) {
+        return service.update(id, saf);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Integer id) {
+        service.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/proyectosaf/presupuesto/persistence/repository/SafRepository.java
+++ b/src/main/java/com/proyectosaf/presupuesto/persistence/repository/SafRepository.java
@@ -1,0 +1,9 @@
+package com.proyectosaf.presupuesto.persistence.repository;
+
+import com.proyectosaf.presupuesto.persistence.entity.SafEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SafRepository extends JpaRepository<SafEntity, Integer> {
+}

--- a/src/main/java/com/proyectosaf/presupuesto/service/SafService.java
+++ b/src/main/java/com/proyectosaf/presupuesto/service/SafService.java
@@ -1,0 +1,13 @@
+package com.proyectosaf.presupuesto.service;
+
+import com.proyectosaf.presupuesto.persistence.entity.SafEntity;
+
+import java.util.List;
+
+public interface SafService {
+    List<SafEntity> findAll();
+    SafEntity findById(Integer id);
+    SafEntity create(SafEntity saf);
+    SafEntity update(Integer id, SafEntity saf);
+    void delete(Integer id);
+}

--- a/src/main/java/com/proyectosaf/presupuesto/service/impl/SafServiceImpl.java
+++ b/src/main/java/com/proyectosaf/presupuesto/service/impl/SafServiceImpl.java
@@ -1,0 +1,47 @@
+package com.proyectosaf.presupuesto.service.impl;
+
+import com.proyectosaf.presupuesto.persistence.entity.SafEntity;
+import com.proyectosaf.presupuesto.persistence.repository.SafRepository;
+import com.proyectosaf.presupuesto.service.SafService;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SafServiceImpl implements SafService {
+
+    private final SafRepository repository;
+
+    @Override
+    public List<SafEntity> findAll() {
+        return repository.findAll();
+    }
+
+    @Override
+    public SafEntity findById(Integer id) {
+        return repository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Saf not found"));
+    }
+
+    @Override
+    public SafEntity create(SafEntity saf) {
+        saf.setId(null);
+        return repository.save(saf);
+    }
+
+    @Override
+    public SafEntity update(Integer id, SafEntity saf) {
+        SafEntity existing = findById(id);
+        existing.setNombre(saf.getNombre());
+        existing.setActivo(saf.getActivo());
+        return repository.save(existing);
+    }
+
+    @Override
+    public void delete(Integer id) {
+        repository.deleteById(id);
+    }
+}

--- a/src/test/java/com/proyectosaf/presupuesto/service/SafServiceImplTest.java
+++ b/src/test/java/com/proyectosaf/presupuesto/service/SafServiceImplTest.java
@@ -1,0 +1,36 @@
+package com.proyectosaf.presupuesto.service;
+
+import com.proyectosaf.presupuesto.persistence.entity.SafEntity;
+import com.proyectosaf.presupuesto.persistence.repository.SafRepository;
+import com.proyectosaf.presupuesto.service.impl.SafServiceImpl;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SafServiceImplTest {
+
+    @Mock
+    private SafRepository repository;
+
+    @InjectMocks
+    private SafServiceImpl service;
+
+    @Test
+    void createDelegatesToRepository() {
+        SafEntity input = SafEntity.builder().nombre("Test").activo(true).build();
+        when(repository.save(any(SafEntity.class))).thenReturn(input);
+
+        SafEntity result = service.create(input);
+
+        verify(repository).save(input);
+        assertEquals("Test", result.getNombre());
+    }
+}


### PR DESCRIPTION
## Summary
- add JPA repository for `SafEntity`
- create service interface and implementation for Saf CRUD operations
- expose REST controller for Saf endpoints and add unit test skeleton

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b83aba2298832eb5e2ac6b2976869b