### PR TITLE
Enable CORS configuration for frontend integration

### DIFF
--- a/src/main/java/com/proyectosaf/presupuesto/config/CorsConfig.java
+++ b/src/main/java/com/proyectosaf/presupuesto/config/CorsConfig.java
@@ -1,0 +1,23 @@
+package com.proyectosaf.presupuesto.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                        .allowedOrigins("*")
+                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                        .allowedHeaders("*");
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- add global CORS configuration to allow cross-origin requests

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b84970101c832e96b0e39eb92175f1