### PR TITLE
Add Lombok MapStruct binding annotation processor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,11 @@
                                                 </path>
                                                 <path>
                                                         <groupId>org.projectlombok</groupId>
+                                                        <artifactId>lombok-mapstruct-binding</artifactId>
+                                                        <version>0.2.0</version>
+                                                </path>
+                                                <path>
+                                                        <groupId>org.projectlombok</groupId>
                                                         <artifactId>lombok</artifactId>
                                                 </path>
                                         </annotationProcessorPaths>


### PR DESCRIPTION
## Summary
- add lombok-mapstruct-binding to annotation processor paths

## Testing
- `mvn clean compile` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.3.2)*

------
https://chatgpt.com/codex/tasks/task_e_68b869cc1b6c832e8297e79709b2d6c5